### PR TITLE
Missing dependency (on std_msgs)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(moveit_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(shape_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 
 rosidl_generate_interfaces(
   ${PROJECT_NAME}
@@ -28,6 +29,7 @@ rosidl_generate_interfaces(
     moveit_msgs
     sensor_msgs
     shape_msgs
+    std_msgs
 )
 
 ament_export_dependencies(rosidl_default_runtime)

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
   <depend>moveit_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>shape_msgs</depend>
+  <depend>std_msgs</depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>


### PR DESCRIPTION
# Issue aimed to resolve

`msg/Object.msg` depends on `std_msgs` but it's missing in the dependency chain.

# Driving issue for making this PR

TBH, I don't know if the issue I'm seeing is rooted in `grasping_msgs` (or `simple_grasping`) pkg. But the pkg names of those are in the error message. 
On one of platforms (where I don't have much control) I keep getting the error:

<details><summary>Full output</summary>

```
$ ros2 action send_goal /find_objects grasping_msgs/action/FindGraspableObjects "{plan_grasps: false}"
Traceback (most recent call last):
  File "/opt/ros/foxy/lib/python3.8/site-packages/rosidl_generator_py/import_type_support_impl.py", line 46, in import_type_support
    return importlib.import_module(module_name, package=pkg_name)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 657, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 556, in module_from_spec
  File "<frozen importlib._bootstrap_external>", line 1166, in create_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
ImportError: /opt/ros/foxy/lib/libstd_msgs__rosidl_generator_c.so: undefined symbol: rosidl_runtime_c__double__Sequence__are_equal

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/ros/foxy/bin/ros2", line 11, in <module>
    load_entry_point('ros2cli==0.9.9', 'console_scripts', 'ros2')()
  File "/opt/ros/foxy/lib/python3.8/site-packages/ros2cli/cli.py", line 67, in main
    rc = extension.main(parser=parser, args=args)
  File "/opt/ros/foxy/lib/python3.8/site-packages/ros2action/command/action.py", line 37, in main
    return extension.main(args=args)
  File "/opt/ros/foxy/lib/python3.8/site-packages/ros2action/verb/send_goal.py", line 54, in main
    return send_goal(args.action_name, args.action_type, args.goal, feedback_callback)
  File "/opt/ros/foxy/lib/python3.8/site-packages/ros2action/verb/send_goal.py", line 95, in send_goal
    action_client = ActionClient(node, action_module, action_name)
  File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/action/client.py", line 148, in __init__
    check_for_type_support(action_type)
  File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/type_support.py", line 29, in check_for_type_support
    msg_type.__class__.__import_type_support__()
  File "/opt/ros/foxy/lib/python3.8/site-packages/grasping_msgs/action/_find_graspable_objects.py", line 1221, in __import_type_support__
    module = import_type_support('grasping_msgs')
  File "/opt/ros/foxy/lib/python3.8/site-packages/rosidl_generator_py/import_type_support_impl.py", line 48, in import_type_support
    raise UnsupportedTypeSupport(pkg_name)
rosidl_generator_py.import_type_support_impl.UnsupportedTypeSupport: Could not import 'rosidl_typesupport_c' for package 'grasping_msgs'
Exception ignored in: <function ActionClient.__del__ at 0x7f5c273a7ee0>
Traceback (most recent call last):
  File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/action/client.py", line 596, in __del__
    self.destroy()
  File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/action/client.py", line 587, in destroy
    if self._client_handle is None:
AttributeError: 'ActionClient' object has no attribute '_client_handle'
```
</details>

With the change in this PR, I still saw the same error output happened, "occasionally" (meaning, the root cause was likely somewhere else. Btw, workaround I accepted was to reboot the OS (equivalent to rebooting all ROS processes).

It's true the dep is missing. I forgot whether transitive dependency on msg/srv/action can be omitted. But for the issue like what I cited above, being specific helps narrowing the debugging scope.